### PR TITLE
Added customizable FURLs

### DIFF
--- a/assets/components/articles/js/container/container.common.js
+++ b/assets/components/articles/js/container/container.common.js
@@ -189,6 +189,20 @@ Articles.panel.ContainerAdvancedSettings = function(config) {
                 ,html: _('articles.setting.otherGetArchives_desc')
                 ,cls: 'desc-under'
 
+            },{
+				xtype: 'textfield'
+                ,name: 'setting_articlefURL'
+                ,id: 'articles-setting-articlefURL'
+                ,fieldLabel: _('articles.setting.articlefURL')
+                ,description: MODx.expandHelp ? '' : _('articles.setting.articlefURL_desc')
+                ,anchor: '100%'
+                ,value: '%Y/%m/%d/%alias/'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'articles-setting-articlefURL'
+                ,html: _('articles.setting.articlefURL_desc')
+                ,cls: 'desc-under'
             }]
         },{
             title: _('articles.settings_pagination')

--- a/core/components/articles/lexicon/de/default.inc.php
+++ b/core/components/articles/lexicon/de/default.inc.php
@@ -147,6 +147,8 @@ $_lang['articles.setting.processTVsList'] = 'Liste zu verarbeitender Template-Va
 $_lang['articles.setting.processTVsList_desc'] = 'Eine optionale, kommaseparierte Liste von Namen von Template-Variablen, die explizit verarbeitet werden. Template-Variablen, die hier angegeben werden, müssen mittels der Einstellungen "Template-Variablen in Übersicht anzeigen" und "Liste einzubeziehender Template-Variablen" einbezogen werden. Werden hier Template-Variablen eingetragen, so werden ausschließlich diese verarbeitet, sonst alle.';
 $_lang['articles.setting.otherGetArchives'] = 'Andere Übersichts-Parameter';
 $_lang['articles.setting.otherGetArchives_desc'] = 'Alle anderen Eigenschaften, die Sie dem getResources-/getPage-Aufruf für die Articles-Übersichtsseite hinzufügen möchten. Verwenden Sie die MODX-Tag-Syntax, als ob Sie die Parameter zum Tag-Aufruf hinzufügen würden (z.B. &eigenschaft=`wert`).';
+$_lang['articles.setting.articlefURL'] = 'URL-Struktur für Artikel'; 
+$_lang['articles.setting.articlefURL_desc'] = '%Y = vierstellige Jahreszahl, %m = Monat (mit führender Null), %d = Tag (mit führender Null), %alias = Alias des Artikels, %id = ID des Artikels, %ext = Dateierweiterung (z.B. html)';
 
 /* template / archives settings */
 $_lang['articles.setting.articleTemplate'] = 'Artikel-Template';

--- a/core/components/articles/lexicon/en/default.inc.php
+++ b/core/components/articles/lexicon/en/default.inc.php
@@ -145,6 +145,8 @@ $_lang['articles.setting.processTVsList'] = 'Process TVs List';
 $_lang['articles.setting.processTVsList_desc'] = 'An optional comma-delimited list of TemplateVar names to process explicitly. TemplateVars specified here must be included via Include TVs/Include TVs List.';
 $_lang['articles.setting.otherGetArchives'] = 'Other Listing Parameters';
 $_lang['articles.setting.otherGetArchives_desc'] = 'Any other properties you would like to add to the getResources/getPage call for the Articles listing page. Put them in MODX tag syntax, as if you were adding it to the tag call (eg, &property=`value`).';
+$_lang['articles.setting.articlefURL'] = 'URL-Structure for Articles'; 
+$_lang['articles.setting.articlefURL_desc'] = '%Y = year, 4 digits, %m = month (with leading zeros), %d = day (with leading zeros), %alias = Article Alias, %id = Article ID, %ext = File extension (e.g. html)';
 
 /* template / archives settings */
 $_lang['articles.setting.articleTemplate'] = 'Article Template';

--- a/core/components/articles/model/articles/article.class.php
+++ b/core/components/articles/model/articles/article.class.php
@@ -255,6 +255,7 @@ class Article extends modResource {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Articles] Could not find Container to set Article URI from.');
             return false;
         }
+		$settings = $container->getContainerSettings();
 
         $date = $this->get('published') ? $this->get('publishedon') : $this->get('createdon');
         $year = date('Y',strtotime($date));
@@ -265,9 +266,23 @@ class Article extends modResource {
         if (empty($containerUri)) {
             $containerUri = $container->get('alias');
         }
-        $uri = rtrim($containerUri,'/').'/'.$year.'/'.$month.'/'.$day.'/'.$this->get('alias');
 
-        $this->set('uri',rtrim($uri,'/').'/');
+        //$uri = rtrim($containerUri,'/').'/'.$year.'/'.$month.'/'.$day.'/'.$this->get('alias');
+        $furlTemplate = $this->xpdo->getOption('articlefURL',$settings,'%Y/%m/%d/%alias/');
+        $furlTemplate = str_replace('%Y', $year, $furlTemplate);
+        $furlTemplate = str_replace('%m', $month, $furlTemplate);
+        $furlTemplate = str_replace('%d', $day, $furlTemplate);
+        $furlTemplate = str_replace('%alias', $this->get('alias'), $furlTemplate);
+        
+        $contentType = $this->xpdo->getObject('modContentType', '');
+        $extension = ltrim($contentType->getExtension(), '.');
+        $furlTemplate = str_replace('%ext', $extension, $furlTemplate);
+        
+        $furlTemplate = str_replace('%id', $this->get('id'), $furlTemplate);
+        
+        $uri = rtrim($containerUri,'/') .'/'. rtrim($furlTemplate);
+        
+        $this->set('uri',$uri);
         $this->set('uri_override',true);
         return $this->get('uri');
     }

--- a/core/components/articles/model/articles/article.class.php
+++ b/core/components/articles/model/articles/article.class.php
@@ -255,6 +255,7 @@ class Article extends modResource {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'[Articles] Could not find Container to set Article URI from.');
             return false;
         }
+		$settings = $container->getContainerSettings();
 
         $date = $this->get('published') ? $this->get('publishedon') : $this->get('createdon');
         $year = date('Y',strtotime($date));
@@ -265,9 +266,23 @@ class Article extends modResource {
         if (empty($containerUri)) {
             $containerUri = $container->get('alias');
         }
-        $uri = rtrim($containerUri,'/').'/'.$year.'/'.$month.'/'.$day.'/'.$this->get('alias');
 
-        $this->set('uri',rtrim($uri,'/').'/');
+        //$uri = rtrim($containerUri,'/').'/'.$year.'/'.$month.'/'.$day.'/'.$this->get('alias');
+        $furlTemplate = $this->xpdo->getOption('articlefURL',$settings,'%Y/%m/%d/%alias/');
+        $furlTemplate = str_replace('%Y', $year, $furlTemplate);
+        $furlTemplate = str_replace('%m', $month, $furlTemplate);
+        $furlTemplate = str_replace('%d', $day, $furlTemplate);
+        $furlTemplate = str_replace('%alias', $this->get('alias'), $furlTemplate);
+        
+        $contentType = $this->xpdo->getObject('modContentType', '');
+        $extension = ltrim($contentType->getExtension(), '.');
+        $furlTemplate = str_replace('%ext', $extension, $furlTemplate);
+        
+        $furlTemplate = str_replace('%id', $this->get('id'), $furlTemplate);
+        
+        $uri = rtrim($containerUri,'/') .'/'. rtrim($furlTemplate);
+        
+        $this->set('uri',rtrim($uri,'/'));
         $this->set('uri_override',true);
         return $this->get('uri');
     }


### PR DESCRIPTION
I just added a quick first version for customizable URLs. The URL-setting will initially use the original structure yyyy/mm/dd/alias/ but can be changed to nearly everything. I included a parameter for the ID and the content-type extension, enabling URLs like blog/testnews-16.html.

Best regards, Daniel
