### PR TITLE
Fix invalid modTransportPackage.source inserted by subpackage resolvers

### DIFF
--- a/_build/resolvers/packages/resolve.archivist.php
+++ b/_build/resolvers/packages/resolve.archivist.php
@@ -32,7 +32,7 @@ if ($transport && $transport->xpdo) {
                 'workspace' => 1,
                 'provider' => 1,
                 'disabled' => false,
-                'source' => $signature.'.transport.zip',
+                'source' => $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'] . '/' . $signature.'.transport.zip',
                 'manifest' => null,
                 'package_name' => $sig[0],
                 'version_major' => $versionSignature[0],

--- a/_build/resolvers/packages/resolve.getpage.php
+++ b/_build/resolvers/packages/resolve.getpage.php
@@ -32,7 +32,7 @@ if ($transport && $transport->xpdo) {
                 'workspace' => 1,
                 'provider' => 1,
                 'disabled' => false,
-                'source' => $signature.'.transport.zip',
+                'source' => $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'] . '/' . $signature.'.transport.zip',
                 'manifest' => null,
                 'package_name' => $sig[0],
                 'version_major' => $versionSignature[0],

--- a/_build/resolvers/packages/resolve.getresources.php
+++ b/_build/resolvers/packages/resolve.getresources.php
@@ -32,7 +32,7 @@ if ($transport && $transport->xpdo) {
                 'workspace' => 1,
                 'provider' => 1,
                 'disabled' => false,
-                'source' => $signature.'.transport.zip',
+                'source' => $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'] . '/' . $signature.'.transport.zip',
                 'manifest' => null,
                 'package_name' => $sig[0],
                 'version_major' => $versionSignature[0],

--- a/_build/resolvers/packages/resolve.quip.php
+++ b/_build/resolvers/packages/resolve.quip.php
@@ -32,7 +32,7 @@ if ($transport && $transport->xpdo) {
                 'workspace' => 1,
                 'provider' => 1,
                 'disabled' => false,
-                'source' => $signature.'.transport.zip',
+                'source' => $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'] . '/' . $signature.'.transport.zip',
                 'manifest' => null,
                 'package_name' => $sig[0],
                 'version_major' => $versionSignature[0],

--- a/_build/resolvers/packages/resolve.taglister.php
+++ b/_build/resolvers/packages/resolve.taglister.php
@@ -32,7 +32,7 @@ if ($transport && $transport->xpdo) {
                 'workspace' => 1,
                 'provider' => 1,
                 'disabled' => false,
-                'source' => $signature.'.transport.zip',
+                'source' => $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'] . '/' . $signature.'.transport.zip',
                 'manifest' => null,
                 'package_name' => $sig[0],
                 'version_major' => $versionSignature[0],


### PR DESCRIPTION
This prevents installation causing odd package management errors for the subpackages, e.g.:

(ERROR @ /revolution/connectors/workspace/packages.php) Could not transfer package taglister-1.1.7-pl.transport.zip to /path/to/revolution/core/packages/.
