### PR TITLE
fix RSS item URLs for MODX sites with non-root site URLs

### DIFF
--- a/core/components/articles/elements/chunks/articlesrssitem.chunk.tpl
+++ b/core/components/articles/elements/chunks/articlesrssitem.chunk.tpl
@@ -1,9 +1,9 @@
 <item>
     <title>[[+pagetitle]]</title>
-    <link>[[++site_url]][[~[[+id]]]]</link>
+    <link>[[~[[+id]]?scheme=`full`]]</link>
     <description>[[+introtext:default=`[[+content:ellipsis=`400`]]`:cdata]]</description>
     <pubDate>[[+publishedon:strtotime:date=`%a, %d %b %Y %H:%M:%S %z`]]</pubDate>
-    <guid>[[++site_url]][[~[[+id]]]]</guid>
+    <guid>[[~[[+id]]?scheme=`full`]]</guid>
     <author>[[+createdby:userinfo=`email`]] ([[+createdby:userinfo=`fullname`]])</author>
     [[!ArticlesStringSplitter? &string=`[[+tv.articlestags]]` &tpl=`sample.ArticlesRssCategoryNode`]]
 </item>


### PR DESCRIPTION
Previous implementation generated URLs like `http://example.com/siteroot//siteroot/blogalias/post`. Besides the duplication of `siteroot`, note also the spurious double slash, which occurred even on sites installed at root URLs.

Using `?scheme=`full`` to generate the full URLs instead of relying on `[[++site_url]]` fixes both these issues.
