### PR TITLE
Allows users to customize date and time formats

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -65,5 +65,21 @@ $settings['articles.article_show_longtitle']->fromArray(array(
     'namespace' => 'articles',
     'area' => 'site',
 ),'',true,true);
+$settings['articles.mgr_date_format']= $modx->newObject('modSystemSetting');
+$settings['articles.mgr_date_format']->fromArray(array(
+    'key' => 'articles.mgr_date_format',
+    'value' => '%b %d',
+    'xtype' => 'textfield',
+    'namespace' => 'articles',
+    'area' => 'site',
+),'',true,true);
+$settings['articles.mgr_time_format']= $modx->newObject('modSystemSetting');
+$settings['articles.mgr_time_format']->fromArray(array(
+    'key' => 'articles.mgr_time_format',
+    'value' => '%H:%I %p',
+    'xtype' => 'textfield',
+    'namespace' => 'articles',
+    'area' => 'site',
+),'',true,true);
 
 return $settings;

--- a/core/components/articles/docs/changelog.txt
+++ b/core/components/articles/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for Articles.
 
+Articles 1.6.4
+===============================
+- [#9508] System Settings added for controlling date and time format for list view in manager.
+
 Articles 1.6.3
 ===============================
 - Enable tag filtering in RSS

--- a/core/components/articles/lexicon/en/default.inc.php
+++ b/core/components/articles/lexicon/en/default.inc.php
@@ -320,7 +320,7 @@ $_lang['articles.setting.commentsGravatar_desc'] = 'Whether or not to show Grava
 $_lang['articles.setting.commentsGravatarIcon'] = 'Gravatar Icon Style';
 $_lang['articles.setting.commentsGravatarIcon_desc'] = 'The type of Gravatar icon to use for a user without a Gravatar.';
 $_lang['articles.setting.commentsGravatarSize'] = 'Gravatar Icon Size';
-$_lang['articles.setting.commentsGravatarSize_desc'] = 'The size in pixels of the Gravatar.';
+$_lang['articles.setting.commentsGravatarSize_desc'] = 'The size in pixels of the Gravatar. Default is 50.';
 $_lang['articles.setting.'] = '';
 $_lang['articles.setting._desc'] = '';
 
@@ -329,13 +329,19 @@ $_lang['setting_articles.article_show_longtitle'] = 'Show Long Title Field';
 $_lang['setting_articles.article_show_longtitle_desc'] = 'Set this option to "Yes" if you want the field "Long Title" to be displayed when editing an article.';
 
 $_lang['setting_articles.default_container_template'] = 'Default Articles Container Template';
-$_lang['setting_articles.default_container_template_desc'] = 'The default Template to use when creating a new Articles Container';
+$_lang['setting_articles.default_container_template_desc'] = 'The default Template (ID) to use when creating a new Articles Container';
 
 $_lang['setting_articles.default_article_template'] = 'Default Article Template';
-$_lang['setting_articles.default_article_template_desc'] = 'The default Template to use when creating a new Article when there is none specified on the Container itself.';
+$_lang['setting_articles.default_article_template_desc'] = 'The default Template (ID) to use when creating a new Article when there is none specified on the Container itself.';
 
 $_lang['setting_articles.container_ids'] = 'Articles FURL IDs';
 $_lang['setting_articles.container_ids_desc'] = 'A comma-separated list of container IDs in use for FURL routing. Best to leave this alone.';
 
 $_lang['setting_articles.default_article_sort_field'] = 'Default Sort Field for Articles In Manager';
-$_lang['setting_articles.default_article_sort_field_desc'] = 'The default sorting field for articles in the grid when editing a Container.';
+$_lang['setting_articles.default_article_sort_field_desc'] = 'The default sorting field for articles in the grid when editing a Container. This field must be a column in the site_content table. TVs not allowed.';
+
+$_lang['setting_articles.mgr_date_format'] = 'Manager Date Format';
+$_lang['setting_articles.mgr_date_format_desc'] = 'Date format displayed inside an article container when listing articles inside the manager.';
+
+$_lang['setting_articles.mgr_time_format'] = 'Manager Time Format';
+$_lang['setting_articles.mgr_time_format_desc'] = 'Time format displayed inside an article container when listing articles inside the manager.';

--- a/core/components/articles/processors/article/getlist.class.php
+++ b/core/components/articles/processors/article/getlist.class.php
@@ -180,9 +180,10 @@ class ArticleGetListProcessor extends modObjectGetListProcessor {
         $resourceArray = parent::prepareRow($object);
 
         if (!empty($resourceArray['publishedon'])) {
-            $resourceArray['publishedon_date'] = strftime('%b %d',strtotime($resourceArray['publishedon']));
-            $resourceArray['publishedon_time'] = strftime('%H:%I %p',strtotime($resourceArray['publishedon']));
-            $resourceArray['publishedon'] = strftime('%b %d, %Y %H:%I %p',strtotime($resourceArray['publishedon']));
+        	$publishedon = strtotime($resourceArray['publishedon']);
+            $resourceArray['publishedon_date'] = strftime($this->modx->getOption('articles.mgr_date_format',null,'%b %d'),$publishedon);
+            $resourceArray['publishedon_time'] = strftime($this->modx->getOption('articles.mgr_time_format',null,'%H:%I %p'),$publishedon);
+            $resourceArray['publishedon'] = strftime('%b %d, %Y %H:%I %p',$publishedon);
         }
         $resourceArray['action_edit'] = '?a='.$this->editAction->get('id').'&action=post/update&id='.$resourceArray['id'];
         if (!array_key_exists('comments',$resourceArray)) $resourceArray['comments'] = 0;


### PR DESCRIPTION
Implements feature 9508:  http://tracker.modx.com/issues/9508
Now allows users to customize date and time formats when viewing a list of articles in a container in the manager.
