### PR TITLE
Update core/components/articles/model/articles/articlescontainer.class.php

### DIFF
--- a/core/components/articles/model/articles/articlescontainer.class.php
+++ b/core/components/articles/model/articles/articlescontainer.class.php
@@ -441,6 +441,7 @@ class ArticlesContainer extends modResource {
         $output = '[[getResources?
             &parents=`'.$this->get('id').'`
             &hideContainers=`1`
+            &includeContent=`1`
             &showHidden=`1`
             &tpl=`'.$this->xpdo->getOption('latestPostsTpl',$settings,'sample.ArticlesLatestPostTpl').'`
             &limit=`'.$this->xpdo->getOption('latestPostsLimit',$settings,5).'`


### PR DESCRIPTION
Added in includeContent param to getResources call since [[+content]]
is set as default if [[+introtext]] is empty.
