### PR TITLE
Update articlesrouter.class.php

### DIFF
--- a/core/components/articles/model/articles/articlesrouter.class.php
+++ b/core/components/articles/model/articles/articlesrouter.class.php
@@ -56,7 +56,7 @@ class ArticlesRouter {
             $archive = explode(':',$archive);
             $archiveId = $archive[0];
             $alias = array_search($archiveId,$this->modx->aliasMap);
-            if ($alias && strpos($search,$alias) !== false) {
+            if ($alias && strpos($search,$alias) != false) {
                 $search = str_replace($alias,'',$search);
                 $resourceId = $archiveId;
                 if (isset($archive[1])) $prefix = $archive[1];


### PR DESCRIPTION
Line 59 is ignored and causes the $resourceid to always be set (to the container id), and therefore when a page is not found, doesn't redirect to the error page.
